### PR TITLE
Disable TypeScript option `"noUncheckedIndexedAccess"` again due to compability issues with SCSS Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.0.8
+=====
+
+* (bug) Disable TypeScript option `"noUncheckedIndexedAccess"` again due to compability issues with SCSS Modules.
+
+
 1.0.7
 =====
 

--- a/tsconfig/library.json
+++ b/tsconfig/library.json
@@ -18,7 +18,7 @@
 		"noEmit": true,
 		"noImplicitThis": true,
 		"noImplicitOverride": true,
-		"noUncheckedIndexedAccess": true,
+		"noUncheckedIndexedAccess": false,
 		"removeComments": false,
 		"resolveJsonModule": true,
 		"skipLibCheck": true,

--- a/tsconfig/next-js.json
+++ b/tsconfig/next-js.json
@@ -15,7 +15,7 @@
 		"moduleResolution": "bundler",
 		"noEmit": true,
 		"noImplicitOverride": true,
-		"noUncheckedIndexedAccess": true,
+		"noUncheckedIndexedAccess": false,
 		"plugins": [
 			{
 				"name": "next"


### PR DESCRIPTION
This is a logical error, which makes sense, as `undefined` is not a valid Object key. And since TypeScript doesn't have more specific information about our SCSS modules, it can't know when we try to construct objects with invalid or valid keys.

Therefore, we'll disable this rule (for now) until we figured out a better solution.